### PR TITLE
Add more twitter/x links

### DIFF
--- a/SlimTwitter/app/src/main/AndroidManifest.xml
+++ b/SlimTwitter/app/src/main/AndroidManifest.xml
@@ -46,6 +46,16 @@ SlimTwitter is an Open Source app realized by Leonardo Rignanese
                 <data
                     android:host="twitter.com"
                     android:scheme="https" />
+                <data
+                    android:host="x.com"
+                    android:scheme="https" />
+                <!-- alternative twitter links, used mainly for embedding -->
+                <data
+                    android:host="fxtwitter.com"
+                    android:scheme="https" />
+                <data
+                    android:host="vxtwitter.com"
+                    android:scheme="https" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
- `x.com` is the new official domain
- `fxtwitter.com` is an alternative embedding domain
- `vxtwitter.com` is an alternative embedding domain